### PR TITLE
fix: Resolve UI layout, element overlap, and input responsiveness issues

### DIFF
--- a/HP12c.css
+++ b/HP12c.css
@@ -1,51 +1,68 @@
-div.calc_model {
-    background-color: lightgray
-    opacity:1;
-    color: red;
-    border: 2px solid black;
-    z-index: 1;
+html, body {
+    margin: 0;
+    padding: 0;
+    font-family: Arial, sans-serif;
+}
+
+/* Main application container styling (optional, can be added in View.elm if needed) */
+/* #elm-app-container { padding: 20px; text-align: center; } */
+
+div.calc_model { /* For existing debug divs */
+    background-color: lightgray;
+    color: red; /* Was red, maybe change to black for better readability */
+    border: 1px solid black;
     font-family: "Courier New", Courier, monospace;
     font-weight: bold;
-    font-size: 30px;
+    font-size: 14px; /* Smaller for debug info */
+    padding: 10px;
+    margin: 10px auto; /* Centered, with space */
+    width: 590px; /* Match calculator width */
+    box-sizing: border-box;
+    /* position: static; by default for divs, remove absolute positioning from inline styles */
+}
+
+.nlp-section, .nlp-display-section { /* For NLP related divs */
+    margin: 10px auto;
+    padding: 10px;
+    border: 1px solid #ddd;
+    width: 590px; /* Match calculator width */
+    box-sizing: border-box;
+    /* position: static; by default for divs, remove absolute positioning from inline styles */
 }
 
 .lcd-display {
-    position: relative; /* Changed from absolute to relative for indicator positioning */
-    top: 40px; 
-    left: 70px; 
-    width: 450px; 
-    height: 50px; 
-    z-index: 1; 
+    position: absolute; 
+    top: 40px;  /* Adjust as needed based on calculator image */
+    left: 70px; /* Adjust as needed based on calculator image */
+    width: 450px; /* Adjust as needed based on calculator image */
+    height: 50px; /* Adjust as needed based on calculator image */
     background-color: #C0C0C0; 
     color: #333333; 
-    font-family: "Courier New", Courier, monospace;
-    font-size: 38px; 
-    text-align: right;
-    padding-right: 10px; /* Padding for main text */
-    padding-left: 30px; /* Add padding for indicators if they are on the left */
-    border: 1px solid #888888;
+    font-family: "Courier New", Courier, monospace; /* Monospaced for LCD feel */
+    font-size: 38px; /* Large font for display */
+    text-align: right; /* Numbers are typically right-aligned */
+    padding-right: 10px; /* Padding for the main text */
+    border: 1px solid #888888; /* LCD border */
     overflow: hidden; 
     white-space: nowrap; 
     box-sizing: border-box; 
-    display: flex; /* Use flex to align items */
+    z-index: 2; /* Above calculator background, below very top elements like hints if any */
+
+    display: flex; /* For internal alignment of modifiers and text */
     align-items: center; /* Vertically center items */
-    justify-content: space-between; /* Space between indicators and main text */
+    justify-content: space-between; /* Modifiers on left, text on right */
 }
 
 .modifier-indicators {
-    /* position: absolute; -- No longer needed if lcd-display is flex container */
-    /* top: 2px; */
-    /* left: 5px; */
     display: flex;
-    gap: 5px;
-    /* padding-left: 5px; -- If not using space-between on parent */
+    gap: 5px; /* Space between f and g */
+    padding-left: 5px; /* Padding from the left edge of LCD */
 }
 
 .f-indicator, .g-indicator {
-    font-size: 16px; /* Smaller, as annunciators */
-    font-family: Arial, sans-serif;
+    font-size: 16px; 
+    font-family: Arial, sans-serif; /* Or another clear, small font */
     font-weight: bold;
-    /* color: #555; -- Base color if not using specific orange/blue */
 }
 
 .f-indicator {
@@ -57,37 +74,39 @@ div.calc_model {
 }
 
 .main-lcd-text {
-    flex-grow: 1; /* Allow main text to take available space */
-    text-align: right; /* Ensure main numbers stay right-aligned */
+    flex-grow: 1; /* Takes up remaining space */
+    text-align: right; /* Ensures the number itself is right-aligned */
 }
 
 div.calculator {
-    position: absolute;
-    width:590px;
-    height:370px;
+    position: relative; /* Container for absolutely positioned LCD and hitboxes */
+    width:590px; /* Intrinsic width of the background image */
+    height:370px; /* Intrinsic height of the background image */
     background-repeat:no-repeat;
-    background-size: cover;
-    background-image: url( DSR_hp12cp.png );
-    opacity: 0.995;
-    z-index: 0;
+    background-size: cover; /* Or contain, depending on desired fit */
+    background-image: url(DSR_hp12cp.png); /* Ensure correct path if CSS is moved */
+    margin: 20px auto; /* Center the calculator on the page */
+    z-index: 1; /* Base for stacking context */
 }
 
 div.transparent_box {
     position: absolute;
-    opacity: 0.9;
-    height: 32px;
-    width: 34px;
-    background-color: green;
+    /* opacity: 0.9; -- Opacity can make it look faded, remove if not desired for hitboxes */
+    /* background-color: green; -- For debugging, make transparent in production */
+    background-color: rgba(0, 255, 0, 0.0); /* Transparent green for debugging, set alpha to 0 for production */
     cursor: pointer;
-    z-index: 1;
+    z-index: 3; /* Above LCD to ensure clickability */
 }
 
-span.hint_key {
+span.hint_key { /* These are children of transparent_box */
     padding: 0;
     margin: 0;
-    color: black;
-    opacity: 1;
+    color: black; /* Or a color that's visible for debugging but hidden for production */
+    /* opacity: 1; -- Controlled by parent or remove if hints always visible */
     font-family: "Courier New", Courier, monospace;
     font-weight: bold;
-    font-size: 30px;
+    font-size: 10px; /* Smaller for hints */
+    position: absolute; /* Position within the transparent_box if needed */
+    top: 0; left: 0;
+    /* visibility: hidden; -- Make hints hidden in production, visible for debug */
 }

--- a/src/HP12c_View.elm
+++ b/src/HP12c_View.elm
@@ -195,7 +195,7 @@ stack_registers_div : Model -> Html Msg
 stack_registers_div model =
     div
         [ classNames [ "calc_model" ]
-        , Html.Attributes.style [ ( "left", "0px" ), ( "top", "574px" ), ( "position", "absolute" ) ]
+        -- Removed inline style for absolute positioning
         ]
         -- Removed "display: " ++ model.displayString
         (List.intersperse empty_br_node (List.map text (String.split "," (toString model.automaticMemoryStackRegisters))))
@@ -205,7 +205,7 @@ input_queue_div : Model -> Html Msg
 input_queue_div model =
     div
         [ classNames [ "calc_model" ]
-        , Html.Attributes.style [ ( "left", "610px" ), ( "top", "0px" ), ( "position", "absolute" ) ]
+        -- Removed inline style for absolute positioning
         ]
         -- Removed "display: " ++ model.displayString
         (List.intersperse empty_br_node (List.map text (String.split "," (toString model.inputQueue))))
@@ -215,7 +215,7 @@ financial_registers_div : Model -> Html Msg
 financial_registers_div model =
     div
         [ classNames [ "calc_model" ]
-        , Html.Attributes.style [ ( "left", "400px" ), ( "top", "574px" ), ( "width", "400" ), ( "position", "absolute" ) ]
+        -- Removed inline style for absolute positioning, width can be handled by CSS if needed
         ]
         (model.financialRegisters
             |> Basics.toString
@@ -235,7 +235,7 @@ modelinfodiv : Model -> Html Msg
 modelinfodiv model =
     div
         [ classNames [ "calc_model" ]
-        , Html.Attributes.style [ ( "left", "0px" ), ( "top", "434px" ), ( "position", "absolute" ) ]
+        -- Removed inline style for absolute positioning
         ]
         [ Html.text (" Current Key       : " ++ model.message ++ " pressed ")
         , empty_br_node


### PR DESCRIPTION
This commit addresses critical UI problems that caused elements to overlap incorrectly and made the calculator unresponsive.

Key changes:

1.  **CSS Adjustments (HP12c.css):**
    *   Added basic `html, body` styling to reset default margins/padding.
    *   Changed `.calculator` div to `position: relative;` and centered it
        using `margin: auto;` for better page flow.
    *   Ensured `.lcd-display` is `position: absolute;` correctly positioned
        within the `.calculator` div, with an appropriate `z-index` (e.g., 2).
        Flexbox properties are used for internal alignment of text and
        modifier indicators.
    *   Adjusted `.transparent_box` (key hitboxes) `z-index` (e.g., 3) to ensure
        they are above the LCD and calculator background, making keys clickable.
    *   Debug/info divs (`.calc_model`) and NLP sections (`.nlp-section`,
        `.nlp-display-section`) now use static positioning with margins,
        allowing them to flow normally in the document instead of
        overlapping.

2.  **View Logic (src/HP12c_View.elm):**
    *   Removed inline `position: absolute` styles from debug/info divs
        to allow external CSS to control their layout effectively.
    *   The structure of how `lcdDisplayDiv` is placed within `button_divs`
        (which renders the `.calculator` div) ensures the LCD is a child
        of the relatively positioned calculator background, allowing
        absolute positioning of the LCD within it.

These changes should restore the visual integrity of the calculator, ensure the new LCD is correctly positioned and updated by direct key input, and make the interface responsive to clicks. The previously reported NLP logic bug (e.g., "5 times 23" error) is a separate issue to be addressed next.